### PR TITLE
No mindshield for heads! & More coins for important roles.

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -140,9 +140,9 @@
   weight: 10
   startingGear: QuartermasterGear
   icon: "JobIconQuarterMaster"
-  supervisors: job-supervisors-captain
-  canBeAntag: false
-  goobcoins: 40 #Goob content
+  supervisors: job-supervisors-hop
+  canBeAntag: true
+  goobcoins: 90 #Goob content
   access:
   - Cargo
   - Salvage
@@ -154,8 +154,6 @@
   - Cryogenics
   - External # goobstation
   special:
-  - !type:AddImplantSpecial
-    implants: [ MindShieldImplant ]
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -154,7 +154,7 @@
       #any MRP using our code might eventually want to use it
     # - !type:SaturationRequirement # MisandryBox - no neon hair on captain
     #   hairColorSaturation: 0.30
-  goobcoins: 50 #Goob content
+  goobcoins: 130 #Goob content
   weight: 20
   startingGear: CaptainGear
   icon: "JobIconCaptain"

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -149,12 +149,12 @@
     - !type:DepartmentTimeRequirement
       department: Command
       time: 36000 # 10 hours
-  goobcoins: 40 #Goob content
+  goobcoins: 90 #Goob content
   weight: 20
   startingGear: HoPGear
   icon: "JobIconHeadOfPersonnel"
   supervisors: job-supervisors-captain
-  canBeAntag: false
+  canBeAntag: true
   access:
   - Command
   - HeadOfPersonnel
@@ -183,8 +183,6 @@
   - Atmospherics
   - Medical
   special:
-  - !type:AddImplantSpecial
-    implants: [ MindShieldImplant ]
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -146,8 +146,8 @@
   startingGear: ChiefEngineerGear
   icon: "JobIconChiefEngineer"
   supervisors: job-supervisors-captain
-  canBeAntag: false
-  goobcoins: 40 #Goob content
+  canBeAntag: true
+  goobcoins: 90 #Goob content
   access:
   - Maintenance
   - Engineering
@@ -158,8 +158,6 @@
   - Brig
   - Cryogenics
   special:
-  - !type:AddImplantSpecial
-    implants: [ MindShieldImplant ]
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -151,8 +151,8 @@
   startingGear: CMOGear
   icon: "JobIconChiefMedicalOfficer"
   supervisors: job-supervisors-captain
-  canBeAntag: false
-  goobcoins: 40 #Goob content
+  canBeAntag: true
+  goobcoins: 90 #Goob content
   access:
   - Medical
   - Command
@@ -163,8 +163,6 @@
   - Cryogenics
   - External # goobstation
   special:
-  - !type:AddImplantSpecial
-    implants: [ MindShieldImplant ]
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -142,8 +142,8 @@
   startingGear: ResearchDirectorGear
   icon: "JobIconResearchDirector"
   supervisors: job-supervisors-captain
-  canBeAntag: false
-  goobcoins: 40 #Goob content
+  canBeAntag: true
+  goobcoins: 90 #Goob content
   access:
   - Research
   - Command
@@ -153,8 +153,6 @@
   - Cryogenics
   - External # goobstation
   special:
-  - !type:AddImplantSpecial
-    implants: [ MindShieldImplant ]
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff

--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -76,7 +76,7 @@
   icon: "JobIconDetective"
   supervisors: job-supervisors-hos
   canBeAntag: false
-  goobcoins: 30 #Goob content
+  goobcoins: 130 #Goob content
   access:
   - Security
   - Brig

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -160,7 +160,7 @@
   icon: "JobIconHeadOfSecurity"
   supervisors: job-supervisors-captain
   canBeAntag: false
-  goobcoins: 45 #Goob content
+  goobcoins: 130 #Goob content
   access:
   - HeadOfSecurity
   - Command

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -107,7 +107,7 @@
   icon: "JobIconSecurityCadet"
   supervisors: job-supervisors-security
   canBeAntag: false
-  goobcoins: 30 #Goob content
+  goobcoins: 130 #Goob content
   access:
   - Security
   - Brig

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -92,7 +92,7 @@
   icon: "JobIconSecurityOfficer"
   supervisors: job-supervisors-hos
   canBeAntag: false
-  goobcoins: 30 #Goob content
+  goobcoins: 130 #Goob content
   access:
   - Security
   - Brig


### PR DESCRIPTION
## About the PR
Removed mindshield implants from heads, allowing them to be antagonists.  
Increased kloins reward for important roles.
All non-mindshielded heads are getting 90 kloins now, Cap and sec are getting 130.

## Why / Balance
Encourages players to take head/security roles by giving them rewards.
Non-Mindshielded heads are already practiced on some ss13 builds

## Technical Details
- Removed mindshield implants from head roles in job definitions
- Increased kloins amount for important roles
- No changes to job selection logic

## Media
Not applicable

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Changelog
:cl:
- remove: Removed mindshield implant for heads — they can now be antags
- tweak: Increased kloins reward for important roles
